### PR TITLE
Create win_cve_23397_davclnt_wav.yml

### DIFF
--- a/2023/2023-03/cve-23397/win_cve_23397_davclnt_wav.yml
+++ b/2023/2023-03/cve-23397/win_cve_23397_davclnt_wav.yml
@@ -1,0 +1,35 @@
+title: Possible CVE-2023-23397
+id: 00c2ad6a-fb88-42c9-bc48-57450e33ea0f
+status: experimental
+description: Detects activity related to CVE-2023-23397 exploitation where webdav is used to grab sound file on UNC request causing client to attempt to authenticate in response. 
+references:
+    - https://www.huntress.com/blog/everything-we-know-about-cve-2023-23397
+author: Huntress DE&TH Team
+date: 2023/03/16
+tags:
+    - attack.exfiltration
+    - attack.t1048.003
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        ParentImage|endswith: '\svchost.exe'
+        Image|endswith: '\rundll32.exe'
+        CommandLine|contains|all: 
+            - 'C:\windows\system32\davclnt.dll,DavSetCookie'
+            - '.WAV'
+    condition: selection
+falsepositives:
+    - unknown
+level: high
+huntress:
+    language: kql
+
+
+
+
+
+
+
+


### PR DESCRIPTION
added entry for cve_23397, specifically a web client abusing pidlid reference causing wav file to show in command line indicative of exploitation.