### PR TITLE
Apache ActiveMQ Post-Exploitation Activity

### DIFF
--- a/2023/2023-11/suspicious_child_process_from_activemq.yml
+++ b/2023/2023-11/suspicious_child_process_from_activemq.yml
@@ -1,0 +1,34 @@
+title: ActiveMQ Exploitation CVE-2023-46604
+id: 73eff0f0-e0fa-4a28-8b71-6287391cf0a2
+description: Apache ActiveMQ server is affected by a critical vulnerability, CVE-2023-46604. Evidence of exploitation has included suspicious child processes including cmd.exe and curl.exe used to download and execute files. This process normally has very few child processes.
+status: experimental
+date: 2023/11/02
+author: Huntress DE&TH Team
+references:
+  - https://www.rapid7.com/blog/post/2023/11/01/etr-suspected-exploitation-of-apache-activemq-cve-2023-46604/
+  - https://activemq.apache.org/security-advisories.data/CVE-2023-46604
+  - https://nvd.nist.gov/vuln/detail/CVE-2023-46604
+
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    Selection1:
+      ParentImage|endswith:
+        - '\java.exe'
+      ParentCommandLine|contains:
+        - '\apache\'
+        - 'ActiveMQ'
+    Filter:
+      Image|endswith:
+        - '\conhost.exe'
+        - '\java.exe'
+    condition: Selection1 and not Filter
+falsepositives:
+    - Unknown
+level: high
+tags:
+  - attack.initial_access
+  - attack.execution
+  - attack.t1190
+  - attack.t1059


### PR DESCRIPTION
New rule to detect possible post-exploitation activity from CVE-2023-46604 on Apache ActiveMQ servers.