### PR TITLE
Add DLL sideloading detections for Exorcising Demons / Havoc campaign

### DIFF
--- a/2026/2026-02/Exorcising_Demons/proc_creation_win_susp_adnotificationmanager_sideloading.yml
+++ b/2026/2026-02/Exorcising_Demons/proc_creation_win_susp_adnotificationmanager_sideloading.yml
@@ -1,0 +1,30 @@
+title: Possible DLL Side-Loading Using ADNotificationManager.exe
+id: ed26d612-bb1b-46d1-92f5-c7d51dc81080
+status: experimental
+description: |
+  Detects ADNotificationManager.exe (Adobe Notification Manager) running from an
+  unusual or unknown directory, which may be indicative of DLL Side-Loading.
+  This binary has been observed being abused by multiple threat actors including
+  GOLD BLADE to sideload malicious DLLs and deliver C2 payloads such as Havoc.
+author: Matt Anderson (Huntress)
+references:
+  - https://news.sophos.com/en-us/2025/07/29/gold-blade-remote-dll-sideloading-attack-deploys-redloader/
+date: 2026/02/27
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  selection_name:
+    OriginalFileName: 'ADNotificationManager.exe'
+    Image|endswith: '\ADNotificationManager.exe'
+  filter_legit:
+    Image|contains:
+      - '\Acrobat'
+      - '\Reader'
+  condition: selection_name and not filter_legit
+falsepositives:
+  - Legitimate usage of ADNotificationManager.exe installed in custom directories
+level: high
+tags:
+  - attack.defense_evasion
+  - attack.t1574.002

--- a/2026/2026-02/Exorcising_Demons/proc_creation_win_susp_dlpuseragent_sideloading.yml
+++ b/2026/2026-02/Exorcising_Demons/proc_creation_win_susp_dlpuseragent_sideloading.yml
@@ -1,0 +1,28 @@
+title: Possible DLL Side-Loading Using DlpUserAgent.exe
+id: 26a153b1-e5e8-4288-b1d1-d4ed6fc1c596
+status: experimental
+description: |
+  Detects DlpUserAgent.exe (Microsoft Defender Data Loss Prevention User Agent)
+  running from an unusual or unknown directory, which may be indicative of DLL
+  Side-Loading. This binary legitimately resides within the Windows Defender
+  directory and has been observed being abused by threat actors to sideload
+  malicious DLLs delivering C2 payloads such as Havoc.
+author: Matt Anderson (Huntress)
+references:
+  - https://attack.mitre.org/techniques/T1574/002/
+date: 2026/02/27
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  selection:
+    OriginalFileName: 'DlpUserAgent.exe'
+  filter_legit:
+    Image|contains: '\Windows Defender\'
+  condition: selection and not filter_legit
+falsepositives:
+  - Unknown
+level: high
+tags:
+  - attack.defense_evasion
+  - attack.t1574.002


### PR DESCRIPTION
## Summary

- **`proc_creation_win_susp_adnotificationmanager_sideloading.yml`** — Detects Adobe's ADNotificationManager.exe running outside its expected `\Acrobat` or `\Reader` install paths. Validated against Huntress fleet (0 FPs in 20h window after filtering legitimate Adobe paths).
- **`proc_creation_win_susp_dlpuseragent_sideloading.yml`** — Detects Microsoft Defender's DlpUserAgent.exe running outside the `Windows Defender` directory.

Both binaries were abused by the adversary to sideload malicious DLLs delivering the Havoc C2 payload from `%PROGRAMDATA%\Adobe\ARM\`.
